### PR TITLE
[JITERA] Implement PATCH /books/:id for Partial Updates

### DIFF
--- a/controllers/bookController.js
+++ b/controllers/bookController.js
@@ -1,4 +1,5 @@
 const bookService = require('../services/bookService');
+const mongoose = require('mongoose');
 
 exports.createBook = async (req, res) => {
     try {
@@ -38,5 +39,28 @@ exports.deleteBook = async (req, res) => {
         res.json(message);
     } catch (error) {
         res.status(404).json({ error: error.message });
+    }
+};
+
+// PATCH handler
+exports.patchBook = async (req, res) => {
+    try {
+        const bookId = req.params.id;
+        if (!mongoose.Types.ObjectId.isValid(bookId)) {
+            return res.status(400).json({ error: 'Invalid book id' });
+        }
+        // Only allow fields: title, author, publishedYear, genre, available
+        const allowedFields = ['title', 'author', 'publishedYear', 'genre', 'available'];
+        const updateData = {};
+        allowedFields.forEach(field => {
+            if (req.body[field] !== undefined) updateData[field] = req.body[field];
+        });
+        if (Object.keys(updateData).length === 0) {
+            return res.status(400).json({ error: 'No valid fields provided for update' });
+        }
+        const book = await bookService.patchBook(bookId, updateData);
+        res.json(book);
+    } catch (error) {
+        res.status(400).json({ error: error.message });
     }
 };

--- a/routes/bookRoutes.js
+++ b/routes/bookRoutes.js
@@ -8,5 +8,8 @@ router.get('/books', bookController.getAllBooks);
 router.get('/books/:id', bookController.getBookById);
 router.put('/books/:id', bookController.updateBook);
 router.delete('/books/:id', bookController.deleteBook);
+// PATCH endpoint for partial updates
+router.patch('/books/:id', bookController.patchBook);
+
 
 module.exports = router;

--- a/services/bookService.js
+++ b/services/bookService.js
@@ -1,7 +1,7 @@
 const Book = require('../models/Book');
 
 const validateBookData = (bookData) => {
-    if (bookData.publishedYear > new Date().getFullYear()) {
+    if (bookData.publishedYear !== undefined && bookData.publishedYear > new Date().getFullYear()) {
         throw new Error('Published year cannot be in the future.');
     }
 };
@@ -35,4 +35,12 @@ exports.deleteBook = async (bookId) => {
     const book = await Book.findByIdAndDelete(bookId);
     if (!book) throw new Error('Book not found');
     return { message: 'Book deleted successfully' };
+};
+
+// PATCH service - partial update
+exports.patchBook = async (bookId, updateData) => {
+    validateBookData(updateData);
+    const book = await Book.findByIdAndUpdate(bookId, updateData, { new: true, runValidators: true });
+    if (!book) throw new Error('Book not found');
+    return book;
 };


### PR DESCRIPTION
## Overview
This pull request implements the PATCH `/books/:id` endpoint for partial updates in the Express+Mongoose project. It allows clients to update specific fields of a book without needing to send the entire book object.

## Changes Made
1. **Route Update**: 
   - Added a new PATCH route in `routes/bookRoutes.js` to handle partial updates for books.
   ```javascript
   router.patch('/books/:id', bookController.patchBook);
   ```

2. **Controller Method**: 
   - Implemented the `patchBook` method in `controllers/bookController.js`. This method validates the ObjectId, filters the request body for allowed fields, and delegates the update to the service layer.
   ```javascript
   exports.patchBook = async (req, res) => {
       // Validation and filtering logic
   };
   ```

3. **Service Logic**: 
   - Added the `patchBook` method in `services/bookService.js`. This method performs the partial update using Mongoose's `findByIdAndUpdate` method and reuses existing validation for the `publishedYear` field only if it is present in the update data.
   ```javascript
   exports.patchBook = async (bookId, updateData) => {
       // Validation and update logic
   };
   ```

## Error Handling
- The implementation includes error handling for invalid ObjectId, no valid fields provided for update, and book not found scenarios.

This enhancement improves the API's flexibility by allowing clients to update only the fields they need to change, reducing the amount of data sent over the network.
